### PR TITLE
Added `isset` to make it usable with Twig

### DIFF
--- a/src/Modler/Model.php
+++ b/src/Modler/Model.php
@@ -35,6 +35,16 @@ class Model
             $this->load($data);
         }
     }
+    
+    /**
+     * Checks if a given property is set on the model.
+     * 
+     * @param string $name Property name
+     */
+    public function __isset($name) 
+    {
+        return array_key_exists($name, $this->properties);    
+    }
 
     /**
      * Set the value of a property


### PR DESCRIPTION
In order to use the dot notation in Twig (i.e. `{{ user.username }}` the object being accessed this way needs to have `__isset` defined, as per [this](http://twig.sensiolabs.org/doc/recipes.html#using-dynamic-object-properties). This solves the problem and makes Gatekeeper (and Modler) objects usable directly in Twig templates.